### PR TITLE
Update tns.xsd schema URL

### DIFF
--- a/snippets/xml.json
+++ b/snippets/xml.json
@@ -268,7 +268,7 @@
     "{N} Page": {
         "prefix": "nspage",
         "body": [
-            "<Page xmlns=\"http://www.nativescript.org/tns.xsd\" loaded=\"onLoaded\" navigatedTo=\"onNavigatedTo\">",
+            "<Page xmlns=\"http://schemas.nativescript.org/tns.xsd\" loaded=\"onLoaded\" navigatedTo=\"onNavigatedTo\">",
             "    $1",
             "</Page>"
         ]


### PR DESCRIPTION
The old schema url no longer points to tns.xsd,
This PR will update it to the correct URL.